### PR TITLE
Bug-19: Fix ubuntu instructions

### DIFF
--- a/go-install/linux.md
+++ b/go-install/linux.md
@@ -1,47 +1,12 @@
 # Personal Linux setup instructions
 
-1. Check your Linux version by running `lsb_release -a` in the terminal.
-
-2. If you have Ubuntu **20.04** use option 1, if you have arch Linux use option 2, for any other version (including Ubuntu 19.04/18.04/16.04) use option 3.
-
-
-## Option 1: Setup instructions for Ubuntu 20.04 LTS (focal)
-
-**Note: this is for Ubuntu 20.04 only. For older Ubuntu versions, use the "Setup instructions for other Linux installations" guide.**
-
-1. Run the following commands in terminal. If bash is not your default shell, substitute `.bashrc` for the appropriate file (e.g. `.zshrc` for zsh).
-
-```bash
-sudo apt-get update
-sudo apt-get install golang=2:1.13~1ubuntu2 --yes
-echo 'export GOPATH="$HOME/go"' >> ~/.bashrc
-echo 'export PATH="$PATH:$GOPATH/bin"' >> ~/.bashrc
-source ~/.bashrc
-```
-
-2. Verify that `go version` shows a go installation of version `>=1.13`.
-
-
-## Option 2: Setup instructions for Arch Linux
-
-1. Run the following commands in terminal. If bash is not your default shell, substitute `.bashrc` for the appropriate file (e.g. `.zshrc` for zsh).
-
-```bash
-sudo pacman -S go
-echo 'export GOPATH="$HOME/go"' >> ~/.bashrc
-echo 'export PATH="$PATH:$GOPATH/bin"' >> ~/.bashrc
-source ~/.bashrc
-```
-
-2. Verify that `go version` shows a go installation of version `>=1.13`.
-
-## Option 3: Setup instructions for other Linux installations
+## Option 1: Setup instructions for most Linux installations
 
 1. Run the following commands in terminal:
 
 ```bash
-wget https://dl.google.com/go/go1.15.1.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.15.1.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.15.3.linux-amd64.tar.gz
 ```
 
 2. Open your `.bashrc` file (`~/.bashrc`) in your editor of choice. Add the following lines to the bottom of the file:
@@ -55,4 +20,18 @@ export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
 
 4. Close and re-open any terminal windows.
 
-5. Verify your installation with the command `go version`. The version **will be `1.15.1`**.
+5. Verify your installation with the command `go version`. The version **will be `1.15.3`**.
+
+## Option 2: Setup instructions for Arch Linux
+
+1. Run the following commands in terminal. If bash is not your default shell, substitute `.bashrc` for the appropriate file (e.g. `.zshrc` for zsh).
+
+```bash
+sudo pacman -S go
+echo 'export GOPATH="$HOME/go"' >> ~/.bashrc
+echo 'export PATH="$PATH:$GOPATH/bin"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+2. Verify that `go version` shows a go installation of version `>1.13.8`.
+


### PR DESCRIPTION
Removed ubuntu 20.04 specific instructions, not just uses standard download method

Resolves #19 